### PR TITLE
Removed drawer and replaced with footer menu Issue#44

### DIFF
--- a/src/layouts/HomeLayout.vue
+++ b/src/layouts/HomeLayout.vue
@@ -2,71 +2,21 @@
   <q-layout view="lHh Lpr lFf">
     <q-header reveal elevated class="bg-primary text-white">
       <q-toolbar>
-        <q-btn flat dense round @click="leftDrawerOpen = !leftDrawerOpen" aria-label="Menu">
-          <q-icon name="menu" />
-        </q-btn>
 
         <q-toolbar-title>
           {{ $t('layouts.home') }}
         </q-toolbar-title>
       </q-toolbar>
     </q-header>
-
-    <q-drawer v-model="leftDrawerOpen" :content-class="$q.theme === 'mat' ? 'bg-grey-3' : null" overlay behavior="mobile" elevated>
-      <q-list no-border link inset-delimiter >
-
-        <q-item to="tasker">
-          <q-item-section avatar>
-            <q-icon name="check_box" />
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>{{ $t('layouts.homeMenu.dailyTasks') }}</q-item-label>
-            <q-item-label caption>{{ $t('layouts.homeMenu.dailyTasksAction') }}</q-item-label>
-          </q-item-section>
-        </q-item>
-
-        <q-item to="profile">
-          <q-item-section avatar>
-            <q-icon name="account_box" />
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>{{ $t('layouts.homeMenu.profile') }}</q-item-label>
-            <q-item-label caption>{{ $t('layouts.homeMenu.profileAction') }}</q-item-label>
-          </q-item-section>
-        </q-item>
-
-        <q-item to="studies">
-          <q-item-section avatar>
-            <q-icon name="settings" />
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>{{ $t('layouts.homeMenu.studies') }}</q-item-label>
-            <q-item-label caption>{{ $t('layouts.homeMenu.studiesAction') }}</q-item-label>
-          </q-item-section>
-        </q-item>
-
-        <q-item to="about">
-          <q-item-section avatar>
-            <q-icon name="help" />
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>{{ $t('layouts.homeMenu.about') }}</q-item-label>
-            <q-item-label caption>{{ $t('layouts.homeMenu.aboutAction') }}</q-item-label>
-          </q-item-section>
-        </q-item>
-
-        <q-item to="test">
-          <q-item-section avatar>
-            <q-icon name="bug_report" />
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>TEST</q-item-label>
-            <q-item-label caption>Test page</q-item-label>
-          </q-item-section>
-        </q-item>
-      </q-list>
-    </q-drawer>
-
+    <q-footer bordered class="elevated">
+      <q-tabs mobile-arrows narrow-indicator dense active-color="secondary" class="bg-white text-black">
+        <q-route-tab class="q-px-sm" to="tasker" icon="check_box">{{ $t('layouts.homeMenu.dailyTasks') }}</q-route-tab>
+        <q-route-tab class="q-px-sm" to="profile" icon="account_box" >{{ $t('layouts.homeMenu.profile') }}</q-route-tab>
+        <q-route-tab class="q-px-sm" to="studies" icon="settings">{{ $t('layouts.homeMenu.studies') }}</q-route-tab>
+        <q-route-tab class="q-px-sm" to="about" icon="help">{{ $t('layouts.homeMenu.about') }}</q-route-tab>
+        <q-route-tab class="q-px-sm" to="test" icon="bug_report">TEST</q-route-tab>
+      </q-tabs>
+    </q-footer>
     <q-page-container>
       <router-view></router-view>
     </q-page-container>


### PR DESCRIPTION
Put the main menu as a footer menu #44

Removed the drawer menu and the hamburger button and replaced them with a footer with q-route-tabs.