### PR TITLE
Implemented pull-and-refresh for the tasks homepage

### DIFF
--- a/src/i18n/en/studies.js
+++ b/src/i18n/en/studies.js
@@ -11,6 +11,8 @@ let studies = {
     newStudyInvite: 'You are invited to a new study!',
     newStudyExtraCriteria: 'Answer the following to know if you are eligible',
     notEligible: 'You are not eligible for this study',
+    foundNoStudies: 'Found no eligible studies',
+    searchingForStudies: 'Searches for new studies',
     noStudies: 'You are currently not participating in any study.',
     joinStudy: 'Join',
     discardStudy: 'Discard',

--- a/src/i18n/en/studies.js
+++ b/src/i18n/en/studies.js
@@ -12,7 +12,7 @@ let studies = {
     newStudyExtraCriteria: 'Answer the following to know if you are eligible',
     notEligible: 'You are not eligible for this study',
     foundNoStudies: 'Found no eligible studies',
-    searchingForStudies: 'Searches for new studies',
+    searchingForStudies: 'Searching for new studies',
     noStudies: 'You are currently not participating in any study.',
     joinStudy: 'Join',
     discardStudy: 'Discard',

--- a/src/layouts/HomeLayout.vue
+++ b/src/layouts/HomeLayout.vue
@@ -25,7 +25,7 @@
       >
         <q-route-tab
           class="q-px-sm"
-          to="tasker"
+          :to="{ name: 'tasker', params: { rescheduleTasks: true, checkNewStudies: true } }"
           icon="check_box"
         >{{ $t('layouts.homeMenu.dailyTasks') }}</q-route-tab>
         <q-route-tab

--- a/src/layouts/TaskLayout.vue
+++ b/src/layouts/TaskLayout.vue
@@ -33,7 +33,7 @@ export default {
   },
   methods: {
     goBack () {
-      this.$router.push({ name: 'tasker' })
+      this.$router.push({ name: 'tasker', params: { rescheduleTasks: true, checkNewStudies: true } })
     }
   }
 }

--- a/src/pages/home/Tasker.vue
+++ b/src/pages/home/Tasker.vue
@@ -27,7 +27,6 @@
         <q-separator inset />
         <q-item-label header>
           {{ $t('studies.tasks.missedTasks') }}
-          <q-btn flat round color="primary" icon="refresh" :loading='loading' @click="refresh(() => {})"/>
         </q-item-label>
         <div>
           <taskListItem v-for="(task, mindex) in tasks.missed" :task="task" :key="mindex"></taskListItem>
@@ -75,7 +74,6 @@ export default {
     return {
       nostudies: false,
       newstudies: false,
-      loading: false,
       tasks: {
         upcoming: [],
         missed: [],
@@ -90,7 +88,6 @@ export default {
   },
   methods: {
     refresh (done) {
-      this.loading = true
       const notify = this.$q.notify({
         group: false,
         spinner: true,

--- a/src/pages/home/Tasker.vue
+++ b/src/pages/home/Tasker.vue
@@ -1,54 +1,57 @@
 <template>
   <q-page padding>
-    <q-banner rounded inline-actions class="bg-warning text-white q-mb-sm" v-if="newstudies" icon="new_releases" type="warning">
+    <q-pull-to-refresh @refresh="refresh" label="Default spinner">
+      <q-banner rounded inline-actions class="bg-warning text-white q-mb-sm" v-if="newstudies" icon="new_releases" type="warning">
         {{ $t('studies.newStudy') }}!
         <template v-slot:action>
           <q-btn color="blue" :label="$t('studies.checkNewStusy')" to="studies"/>
         </template>
-    </q-banner>
-
-    <div v-if="nostudies" class="q-title">
-      {{ $t('studies.noStudies') }}
-    </div>
-    <q-list v-else highlight>
-      <q-item-label header>{{ $t('studies.tasks.pendingTasks') }}</q-item-label>
-      <!--<study-active v-for="study in activeStudies" v-bind:study="study" v-bind:key="study.id"></study-active>-->
-      <div>
-        <taskListItem v-for="(task, uindex) in tasks.upcoming" :task="task" :key="uindex"></taskListItem>
-      </div>
-      <q-item v-if="tasks.upcoming.length === 0">
-        <q-item-section avatar>
-          <q-icon color="primary" name="check" />
-        </q-item-section>
-        <q-item-section>
-          <q-item-label>{{ $t('studies.tasks.noPendingTasks') }}</q-item-label>
-        </q-item-section>
-      </q-item>
-      <q-separator inset />
-      <q-item-label header>{{ $t('studies.tasks.missedTasks') }}</q-item-label>
-      <div>
-        <taskListItem v-for="(task, mindex) in tasks.missed" :task="task" :key="mindex"></taskListItem>
-      </div>
-      <q-item v-if="tasks.missed.length === 0">
-        <q-item-section avatar>
-          <q-icon color="primary" name="check" />
-        </q-item-section>
-        <q-item-section>
-          <q-item-label>{{ $t('studies.tasks.noMissedTasks') }}</q-item-label>
-        </q-item-section>
-      </q-item>
-    </q-list>
-
-    <q-dialog v-if="this.tasks.completedStudyAlert" v-model="completedStudyModal" maximized>
-      <div class="q-pa-lg text-center" style="background-color:white">
-        <div class="text-h4 q-mb-md">{{ $t('studies.studyCompletedHeadline') }}!</div>
+      </q-banner>
+      <div v-if="nostudies" class="q-title">{{ $t('studies.noStudies') }}</div>
+      <q-list v-else highlight>
+        <q-item-label header>
+          {{ $t('studies.tasks.pendingTasks') }}
+        </q-item-label>
+        <!--<study-active v-for="study in activeStudies" v-bind:study="study" v-bind:key="study.id"></study-active>-->
         <div>
-          <img src="statics/icons/confetti.svg" style="width:30vw; max-width:150px;">
+          <taskListItem v-for="(task, uindex) in tasks.upcoming" :task="task" :key="uindex"></taskListItem>
         </div>
-        <p v-html="$t('studies.studyCompletedText', { studyname: completedStudyTitle })"></p>
-        <q-btn color="primary" @click="studyCompleted()" :label="$t('common.close')" />
-      </div>
-    </q-dialog>
+        <q-item v-if="tasks.upcoming.length === 0">
+          <q-item-section avatar>
+            <q-icon color="primary" name="check" />
+          </q-item-section>
+          <q-item-section>
+            <q-item-label>{{ $t('studies.tasks.noPendingTasks') }}</q-item-label>
+          </q-item-section>
+        </q-item>
+        <q-separator inset />
+        <q-item-label header>
+          {{ $t('studies.tasks.missedTasks') }}
+          <q-btn flat round color="primary" icon="refresh" :loading='loading' @click="refresh(() => {})"/>
+        </q-item-label>
+        <div>
+          <taskListItem v-for="(task, mindex) in tasks.missed" :task="task" :key="mindex"></taskListItem>
+        </div>
+        <q-item v-if="tasks.missed.length === 0">
+          <q-item-section avatar>
+            <q-icon color="primary" name="check" />
+          </q-item-section>
+          <q-item-section>
+            <q-item-label>{{ $t('studies.tasks.noMissedTasks') }}</q-item-label>
+          </q-item-section>
+        </q-item>
+      </q-list>
+    </q-pull-to-refresh>
+      <q-dialog v-if="this.tasks.completedStudyAlert" v-model="completedStudyModal" maximized>
+        <div class="q-pa-lg text-center" style="background-color:white">
+          <div class="text-h4 q-mb-md">{{ $t('studies.studyCompletedHeadline') }}!</div>
+          <div>
+            <img src="statics/icons/confetti.svg" style="width:30vw; max-width:150px;">
+          </div>
+          <p v-html="$t('studies.studyCompletedText', { studyname: completedStudyTitle })"></p>
+          <q-btn color="primary" @click="studyCompleted()" :label="$t('common.close')" />
+        </div>
+      </q-dialog>
   </q-page>
 </template>
 
@@ -72,6 +75,7 @@ export default {
     return {
       nostudies: false,
       newstudies: false,
+      loading: false,
       tasks: {
         upcoming: [],
         missed: [],
@@ -85,29 +89,51 @@ export default {
     this.load()
   },
   methods: {
+    refresh (done) {
+      this.loading = true
+      const notify = this.$q.notify({
+        group: false,
+        spinner: true,
+        type: 'ongoing',
+        message: this.$i18n.t('studies.searchingForStudies') + '...',
+        timeout: 0
+      })
+      setTimeout(() => {
+        this.checkForStudy()
+        done()
+        notify({
+          type: this.newstudies ? 'positive' : 'warning',
+          spinner: false,
+          message: this.newstudies ? this.$i18n.t('studies.newStudyInvite') : this.$i18n.t('studies.foundNoStudies'),
+          timeout: 1000
+        })
+        this.loading = false
+      }, 1000)
+    },
+    async checkForStudy () {
+      if (this.checkNewStudies) {
+        // let's see if there are any new eligible studies
+        try {
+          let newStudyIds = await API.getNewStudiesKeys()
+          if (newStudyIds.length > 0) {
+            // there's a new study in town! warn the user!
+            this.newstudies = true
+          } else {
+            this.newstudies = false
+          }
+        } catch (error) {
+          console.error('Cannot connect to server, but thats OK', error)
+          // if it fails it's fine
+        }
+      }
+    },
     async load () {
       this.$q.loading.show()
       try {
-        if (this.checkNewStudies) {
-          // let's see if there are any new eligible studies
-          try {
-            let newStudyIds = await API.getNewStudiesKeys()
-            if (newStudyIds.length > 0) {
-              // there's a new study in town! warn the user!
-              this.newstudies = true
-            } else {
-              this.newstudies = false
-            }
-          } catch (error) {
-            console.error('Cannot connect to server, but thats OK', error)
-            // if it fails it's fine
-          }
-        }
-
+        this.checkForStudy()
         if (this.rescheduleTasks) {
           // the first time we show this component, tasks are re-scheduled
           await scheduler.cancelNotifications()
-
           try {
             // let's retrieve the studies from the API, just in case
             let profile = await API.getProfile(userinfo.user._key)


### PR DESCRIPTION
This pull request adds pull-and-refresh functionality so that the user can refresh the page to see if there are any new studies available. There is also a manual spinner icon if the user wants to refresh the page without pulling down.