### PR TITLE
Task parameters are sent through props without :studyKey and :taskID

### DIFF
--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -32,21 +32,22 @@ export default {
   },
   methods: {
     changeRoute: function () {
-      // // // // // // // // // // // DEBUGGING //
-      console.log('TEST')
-      console.log('taskID:', this.task.taskID)
-      console.log('studyKey:', this.task.studyKey)
-      console.log('iconName:', this.icon)
+      let icon = this.icon
+      let studyKey = this.task.studyKey
+      let taskId = this.task.taskId
+      let formKey = this.task.formKey
+
+      console.log(this.title, '\nStudy Key:', studyKey, '\nTask ID:', taskId, '\nForm Key:', formKey)
 
       // these bring the user to the correct route depending on the task
       if (this.task.formKey) {
-        this.$router.push({ name: 'form', params: { iconName: this.icon, studyKey: this.task.studyKey, taskId: this.task.taskID, formKey: this.task.formKey } })
+        this.$router.push({ name: 'form', params: { icon: icon, studyKey: studyKey, taskId: taskId, formKey: formKey } })
       } else if (this.task.type === 'smwt') {
-        this.$router.push({ name: 'smwtIntro', params: { iconName: this.icon, studyKey: this.task.studyKey, taskID: this.task.taskID } })
+        this.$router.push({ name: 'smwtIntro', params: { icon: icon, studyKey: studyKey, taskId: taskId } })
       } else if (this.task.type === 'qcst') {
-        this.$router.push({ name: 'qcstIntro', params: { iconName: this.icon, studyKey: this.task.studyKey, taskID: this.task.taskID } })
-      } else if (this.task.studyKey && this.task.taskID) {
-        this.$router.push({ name: 'dataQuery', params: { iconName: this.icon, taskID: this.task.taskID, studyKey: this.task.studyKey } })
+        this.$router.push({ name: 'qcstIntro', params: { icon: icon, studyKey: studyKey, taskId: taskId } })
+      } else if (this.task.studyKey && this.task.taskId) {
+        this.$router.push({ name: 'dataQuery', params: { icon: icon, taskId: taskId, studyKey: studyKey } })
       } else {
         return false
       }

--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -37,7 +37,7 @@ export default {
       let taskId = this.task.taskId
       let formKey = this.task.formKey
 
-      console.log(this.title, '\nStudy Key:', studyKey, '\nTask ID:', taskId, '\nForm Key:', formKey)
+      console.log(this.title, '\nIcon:', icon, '\nStudy Key:', studyKey, '\nTask ID:', taskId)
 
       // these bring the user to the correct route depending on the task
       if (this.task.formKey) {

--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -1,13 +1,19 @@
 <template>
-  <q-item :to="toAddress">
+  <q-item @click.native="changeRoute">
     <q-item-section avatar>
-      <q-icon color="grey" :name="icon" />
+      <q-icon
+        color="grey"
+        :name="icon"
+      />
     </q-item-section>
     <q-item-section>
       <q-item-label>{{ title }}</q-item-label>
       <q-item-label caption>{{ main }}</q-item-label>
     </q-item-section>
-    <q-item-section side top>{{ timeRemaining }}</q-item-section>
+    <q-item-section
+      side
+      top
+    >{{ timeRemaining }}</q-item-section>
   </q-item>
 </template>
 
@@ -22,6 +28,28 @@ export default {
       icon: undefined,
       title: undefined,
       main: undefined
+    }
+  },
+  methods: {
+    changeRoute: function () {
+      // // // // // // // // // // // DEBUGGING //
+      console.log('TEST')
+      console.log('taskID:', this.task.taskID)
+      console.log('studyKey:', this.task.studyKey)
+      console.log('iconName:', this.icon)
+
+      // these bring the user to the correct route depending on the task
+      if (this.task.formKey) {
+        this.$router.push({ name: 'form', params: { iconName: this.icon, studyKey: this.task.studyKey, taskId: this.task.taskID, formKey: this.task.formKey } })
+      } else if (this.task.type === 'smwt') {
+        this.$router.push({ name: 'smwtIntro', params: { iconName: this.icon, studyKey: this.task.studyKey, taskID: this.task.taskID } })
+      } else if (this.task.type === 'qcst') {
+        this.$router.push({ name: 'qcstIntro', params: { iconName: this.icon, studyKey: this.task.studyKey, taskID: this.task.taskID } })
+      } else if (this.task.studyKey && this.task.taskID) {
+        this.$router.push({ name: 'dataQuery', params: { iconName: this.icon, taskID: this.task.taskID, studyKey: this.task.studyKey } })
+      } else {
+        return false
+      }
     }
   },
   created () {
@@ -48,22 +76,6 @@ export default {
   computed: {
     timeRemaining: function () {
       return 'Due ' + moment(this.task.due).fromNow()
-    },
-    toAddress: function () {
-      // these bring the user to the correct route depending on the task
-      if (this.task.formKey) {
-        return 'form/' + this.task.studyKey + '/' + this.task.taskID + '/' + this.task.formKey
-      } else if (this.task.type === 'smwt') {
-        return 'smwtIntro/' + this.task.studyKey + '/' + this.task.taskID
-      } else if (this.task.type === 'qcst') {
-        return 'qcstIntro/' + this.task.studyKey + '/' + this.task.taskID
-      } else if (this.task.studyKey && this.task.taskID) {
-        return 'dataQuery/' + this.task.studyKey + '/' + this.task.taskID
-      } else if (this.task.studyKey && this.task.taskID) {
-        return 'miband3Intro/' + this.task.studyKey + '/' + this.task.taskID
-      } else {
-        return false
-      }
     }
   }
 }

--- a/src/layouts/TaskLayout.vue
+++ b/src/layouts/TaskLayout.vue
@@ -1,23 +1,52 @@
 <template>
   <q-layout view="lHh Lpr lFf">
-    <q-header reveal elevated class="bg-primary text-white">
+    <q-header
+      reveal
+      elevated
+      class="bg-primary text-white"
+    >
       <q-toolbar id="tasker">
-        <q-btn flat dense @click="confirm = true" icon-right="clear" :label="$t('layouts.close')" />
+        <q-btn
+          flat
+          dense
+          @click="confirm = true"
+          icon-right="clear"
+          :label="$t('layouts.close')"
+        />
       </q-toolbar>
     </q-header>
     <q-page-container>
-      <q-dialog v-model="confirm" persistent>
-      <q-card>
-        <q-card-section class="row items-center">
-          <q-avatar icon="warning" color="negative" text-color="white" size="lg" />
-          <span class="q-ml-sm">{{ $t('studies.tasks.cancelTask') }}</span>
-        </q-card-section>
-        <q-card-actions align="right">
-          <q-btn flat label="Quit task" color="primary" v-close-popup @click="goBack()" />
-          <q-btn flat label="Cancel" color="primary" v-close-popup />
-        </q-card-actions>
-      </q-card>
-    </q-dialog>
+      <q-dialog
+        v-model="confirm"
+        persistent
+      >
+        <q-card>
+          <q-card-section class="row items-center">
+            <q-avatar
+              icon="warning"
+              color="negative"
+              text-color="white"
+              size="lg"
+            />
+            <span class="q-ml-sm">{{ $t('studies.tasks.cancelTask') }}</span>
+          </q-card-section>
+          <q-card-actions align="right">
+            <q-btn
+              flat
+              label="Quit task"
+              color="primary"
+              v-close-popup
+              @click="goBack()"
+            />
+            <q-btn
+              flat
+              label="Cancel"
+              color="primary"
+              v-close-popup
+            />
+          </q-card-actions>
+        </q-card>
+      </q-dialog>
       <router-view />
     </q-page-container>
   </q-layout>

--- a/src/modules/scheduler.js
+++ b/src/modules/scheduler.js
@@ -13,8 +13,8 @@ import HealthDataEnum from './healthDataTypesEnum'
 // studiesParts: the participation to studies
 // studiesDescr: description of the studies, at least those that have been consented
 // returns an object with:
-// upcoming: an array of {type: 'form', studyKey: '2121', taskID: 1, missed: false, due: '2019-04-02'}
-// missed: an array of {type: 'form', studyKey: '2121', taskID: 1, missed: true, due: '2019-04-02'}
+// upcoming: an array of {type: 'form', studyKey: '2121', taskId: 1, missed: false, due: '2019-04-02'}
+// missed: an array of {type: 'form', studyKey: '2121', taskId: 1, missed: true, due: '2019-04-02'}
 // if there is a study that has been completed because no tasks are to be done
 // then the returned object also contains:
 // completedStudyAlert: an object like { studyTitle: 'MyStudy', studyPart: participation object for that study }
@@ -85,7 +85,7 @@ export function generateTasker (studiesParts, studiesDescr) {
         let templateObj = {
           type: task.type,
           studyKey: studyDescr._key,
-          taskID: task.id
+          taskId: task.id
         }
         if (task.type === 'form') {
           templateObj.formTitle = task.formName

--- a/src/pages/tasks/DataQuery.vue
+++ b/src/pages/tasks/DataQuery.vue
@@ -3,10 +3,24 @@
     <!-- content -->
     <div v-if="chartData">
       <p style="margin-top: 0">{{$t('studies.tasks.dataQuery.dataQueryExplanation')}}</p>
-      <bar-chart v-if="plotBar" :chart-data="chartData" :options="chartOptions"></bar-chart>
-      <line-chart v-if="plotLine" :chart-data="chartData" :options="chartOptions"></line-chart>
+      <bar-chart
+        v-if="plotBar"
+        :chart-data="chartData"
+        :options="chartOptions"
+      ></bar-chart>
+      <line-chart
+        v-if="plotLine"
+        :chart-data="chartData"
+        :options="chartOptions"
+      ></line-chart>
       <div class="row">
-        <q-btn color="primary" :loading="loading" class="col" :label="$t('common.send')" @click="submit()" />
+        <q-btn
+          color="primary"
+          :loading="loading"
+          class="col"
+          :label="$t('common.send')"
+          @click="submit()"
+        />
       </div>
     </div>
   </q-page>
@@ -39,6 +53,10 @@ const chartColors = [
 
 export default {
   name: 'DataQueryPage',
+  props: {
+    studyKey: String,
+    taskID: String
+  },
   components: { BarChart, LineChart },
   data: function () {
     return {
@@ -54,8 +72,8 @@ export default {
   },
   async mounted () {
     this.$q.loading.show()
-    const studyKey = this.$route.params.studyKey
-    const taskID = this.$route.params.taskID
+    const studyKey = this.studyKey
+    const taskID = this.taskID
 
     const studyDescr = await DB.getStudyDescription(studyKey)
     this.taskDescr = studyDescr.tasks.find(x => x.id === Number(taskID))
@@ -285,8 +303,8 @@ export default {
     async submit () {
       this.loading = true
       try {
-        let studyKey = this.$route.params.studyKey
-        let taskId = Number(this.$route.params.taskID)
+        let studyKey = this.studyKey
+        let taskId = Number(this.taskID)
         await API.sendDataQuery({
           userKey: userinfo.user._key,
           studyKey: studyKey,

--- a/src/pages/tasks/DataQuery.vue
+++ b/src/pages/tasks/DataQuery.vue
@@ -54,9 +54,9 @@ const chartColors = [
 export default {
   name: 'DataQueryPage',
   props: {
-    iconName: String,
+    icon: String,
     studyKey: String,
-    taskID: Number
+    taskId: Number
   },
   components: { BarChart, LineChart },
   data: function () {
@@ -74,18 +74,13 @@ export default {
   async mounted () {
     this.$q.loading.show()
     const studyKey = this.studyKey
-    const taskID = this.taskID
-
-    console.log('DATAQUERY studyKey:', this.studyKey)
-    console.log('DATAQUERY taskID:', this.taskID)
-    console.log('DATAQUERY PARAM iconName:', this.$route.params.iconName)
-    console.log('DATAQUERY prop iconName:', this.iconName)
+    const taskId = this.taskId
 
     const studyDescr = await DB.getStudyDescription(studyKey)
-    this.taskDescr = studyDescr.tasks.find(x => x.id === Number(taskID))
+    this.taskDescr = studyDescr.tasks.find(x => x.id === Number(taskId))
 
     let studyParticipation = await DB.getStudyParticipation(studyKey)
-    let lastCompleted = studyParticipation.taskItemsConsent.find(x => x.taskId === Number(taskID)).lastExecuted
+    let lastCompleted = studyParticipation.taskItemsConsent.find(x => x.taskId === Number(taskId)).lastExecuted
 
     let startDate = moment()
 
@@ -310,7 +305,7 @@ export default {
       this.loading = true
       try {
         let studyKey = this.studyKey
-        let taskId = Number(this.taskID)
+        let taskId = Number(this.taskId)
         await API.sendDataQuery({
           userKey: userinfo.user._key,
           studyKey: studyKey,

--- a/src/pages/tasks/DataQuery.vue
+++ b/src/pages/tasks/DataQuery.vue
@@ -54,8 +54,9 @@ const chartColors = [
 export default {
   name: 'DataQueryPage',
   props: {
+    iconName: String,
     studyKey: String,
-    taskID: String
+    taskID: Number
   },
   components: { BarChart, LineChart },
   data: function () {
@@ -74,6 +75,11 @@ export default {
     this.$q.loading.show()
     const studyKey = this.studyKey
     const taskID = this.taskID
+
+    console.log('DATAQUERY studyKey:', this.studyKey)
+    console.log('DATAQUERY taskID:', this.taskID)
+    console.log('DATAQUERY PARAM iconName:', this.$route.params.iconName)
+    console.log('DATAQUERY prop iconName:', this.iconName)
 
     const studyDescr = await DB.getStudyDescription(studyKey)
     this.taskDescr = studyDescr.tasks.find(x => x.id === Number(taskID))

--- a/src/pages/tasks/Form.vue
+++ b/src/pages/tasks/Form.vue
@@ -114,7 +114,7 @@ export default {
   props: {
     formKey: String,
     studyKey: String,
-    taskId: String
+    taskId: Number
   },
   data: function () {
     return {

--- a/src/pages/tasks/Form.vue
+++ b/src/pages/tasks/Form.vue
@@ -112,9 +112,10 @@ import userinfo from 'modules/userinfo'
 export default {
   name: 'FormPage',
   props: {
-    formKey: String,
+    icon: String,
     studyKey: String,
-    taskId: Number
+    taskId: Number,
+    formKey: String
   },
   data: function () {
     return {

--- a/src/pages/tasks/Form.vue
+++ b/src/pages/tasks/Form.vue
@@ -2,51 +2,102 @@
   <q-page padding>
     <div v-if="introduction">
       <div class="text-center text-h6">
-          {{introduction.title[$i18n.locale]}}
+        {{introduction.title[$i18n.locale]}}
       </div>
       <div class="text-center text-body1 q-mt-lg">
-          <div v-html="introduction.description[$i18n.locale]"></div>
+        <div v-html="introduction.description[$i18n.locale]"></div>
       </div>
       <div class="row justify-center q-mt-lg">
-          <q-btn color="primary" @click="start()" :label="$t('common.start')" />
+        <q-btn
+          color="primary"
+          @click="start()"
+          :label="$t('common.start')"
+        />
       </div>
     </div>
 
     <div v-if="!introduction && !finished">
       <div class="text-center text-subtitle1">
-          <div v-html="currentQuestion.text[$i18n.locale]"></div>
+        <div v-html="currentQuestion.text[$i18n.locale]"></div>
       </div>
-      <div v-if="currentQuestion.helper" class="text-center text-subtitle2 q-mb-md">
-          <div v-html="currentQuestion.helper[$i18n.locale]"></div>
+      <div
+        v-if="currentQuestion.helper"
+        class="text-center text-subtitle2 q-mb-md"
+      >
+        <div v-html="currentQuestion.helper[$i18n.locale]"></div>
       </div>
-      <q-input v-show="currentQuestion.type === 'freetext'" v-model="freetextAnswer" type="textarea" :label="$t('studies.tasks.form.freeTextExplanation')" rows="5"></q-input>
+      <q-input
+        v-show="currentQuestion.type === 'freetext'"
+        v-model="freetextAnswer"
+        type="textarea"
+        :label="$t('studies.tasks.form.freeTextExplanation')"
+        rows="5"
+      ></q-input>
 
-      <div v-show="currentQuestion.type === 'singleChoice'" v-for="(answerChoice, index) in currentQuestion.answerChoices" :key="'sc' + index">
-        <q-radio v-model="singleChoiceAnswer" :val="answerChoice.id" :label="answerChoice.text[$i18n.locale]"/>
+      <div
+        v-show="currentQuestion.type === 'singleChoice'"
+        v-for="(answerChoice, index) in currentQuestion.answerChoices"
+        :key="'sc' + index"
+      >
+        <q-radio
+          v-model="singleChoiceAnswer"
+          :val="answerChoice.id"
+          :label="answerChoice.text[$i18n.locale]"
+        />
       </div>
-      <div v-show="currentQuestion.type === 'multiChoice'" v-for="(answerChoice, index) in currentQuestion.answerChoices" :key="'mc' + index">
-        <q-checkbox v-model="multiChoiceAnswer" :val="answerChoice.id" :label="answerChoice.text[$i18n.locale]"/>
+      <div
+        v-show="currentQuestion.type === 'multiChoice'"
+        v-for="(answerChoice, index) in currentQuestion.answerChoices"
+        :key="'mc' + index"
+      >
+        <q-checkbox
+          v-model="multiChoiceAnswer"
+          :val="answerChoice.id"
+          :label="answerChoice.text[$i18n.locale]"
+        />
       </div>
-      <div v-show="currentQuestion.type === 'textOnly'" class="text-subtitle1 q-mb-md">
+      <div
+        v-show="currentQuestion.type === 'textOnly'"
+        class="text-subtitle1 q-mb-md"
+      >
         <div v-if="currentQuestion.type === 'textOnly'">
           <div v-html="currentQuestion.html[$i18n.locale]"></div>
         </div>
       </div>
       <div class="row justify-around q-ma-lg">
-        <q-btn v-show="!isFirstQuestion" icon="arrow_back" color="secondary" @click="back()" :label="$t('common.back')" />
-        <q-btn icon-right="arrow_forward" color="primary" @click="next()" :label="$t('common.next')" />
+        <q-btn
+          v-show="!isFirstQuestion"
+          icon="arrow_back"
+          color="secondary"
+          @click="back()"
+          :label="$t('common.back')"
+        />
+        <q-btn
+          icon-right="arrow_forward"
+          color="primary"
+          @click="next()"
+          :label="$t('common.next')"
+        />
       </div>
-      <div v-if="currentQuestion.footer" class="text-left text-caption absolute-bottom q-pa-sm">
-          {{currentQuestion.footer[$i18n.locale]}}
+      <div
+        v-if="currentQuestion.footer"
+        class="text-left text-caption absolute-bottom q-pa-sm"
+      >
+        {{currentQuestion.footer[$i18n.locale]}}
       </div>
     </div>
 
     <div v-if="finished">
       <div class="text-center text-h6">
-          {{$t('studies.tasks.form.formCompleted')}}
+        {{$t('studies.tasks.form.formCompleted')}}
       </div>
       <div class="row justify-around q-ma-lg">
-        <q-btn color="primary" @click="send()" :loading="loading" :label="$t('common.send')" />
+        <q-btn
+          color="primary"
+          @click="send()"
+          :loading="loading"
+          :label="$t('common.send')"
+        />
       </div>
     </div>
 
@@ -60,6 +111,11 @@ import userinfo from 'modules/userinfo'
 
 export default {
   name: 'FormPage',
+  props: {
+    formKey: String,
+    studyKey: String,
+    taskId: String
+  },
   data: function () {
     return {
       formDescr: {},
@@ -77,7 +133,7 @@ export default {
     }
   },
   async created () {
-    const formKey = this.$route.params.formKey
+    const formKey = this.formKey
 
     try {
       let formDescr = await DB.getFormDescription(formKey)
@@ -198,8 +254,8 @@ export default {
     },
     async send () {
       this.loading = true
-      const studyKey = this.$route.params.studyKey
-      const taskId = Number(this.$route.params.taskId)
+      const studyKey = this.studyKey
+      const taskId = Number(this.taskId)
       let answers = {
         userKey: userinfo.user._key,
         studyKey: studyKey,

--- a/src/pages/tasks/Form.vue
+++ b/src/pages/tasks/Form.vue
@@ -135,6 +135,7 @@ export default {
   },
   async created () {
     const formKey = this.formKey
+    console.log('Form Key:', formKey)
 
     try {
       let formDescr = await DB.getFormDescription(formKey)

--- a/src/pages/tasks/QCST.vue
+++ b/src/pages/tasks/QCST.vue
@@ -1,30 +1,55 @@
 <template>
   <q-page padding>
-      <div class="text-center text-h6 q-mt-lg">
-        {{ $t('studies.tasks.qcst.title') }}
-      </div>
+    <div class="text-center text-h6 q-mt-lg">
+      {{ $t('studies.tasks.qcst.title') }}
+    </div>
 
-      <p id="timer"> {{ minutes }}:{{ seconds }} </p>
-      <div class="row justify-center q-mt-lg">
-        <q-btn  @click="startTest" v-if="!isStarted" color="secondary" :label="$t('common.start')" />
-        <q-btn  @click="completeTest" v-if="isStarted" color="purple" :label="$t('common.complete')" />
-      </div>
+    <p id="timer"> {{ minutes }}:{{ seconds }} </p>
+    <div class="row justify-center q-mt-lg">
+      <q-btn
+        @click="startTest"
+        v-if="!isStarted"
+        color="secondary"
+        :label="$t('common.start')"
+      />
+      <q-btn
+        @click="completeTest"
+        v-if="isStarted"
+        color="purple"
+        :label="$t('common.complete')"
+      />
+    </div>
 
-      <audio ref="sound_begin">
-        <source src="statics/sounds/begin.wav" type="audio/wav"/>
-      </audio>
-      <audio ref="sound_minute1">
-        <source src="statics/sounds/1-minute.wav" type="audio/wav"/>
-      </audio>
-      <audio ref="sound_minute2">
-        <source src="statics/sounds/2-minutes.wav" type="audio/wav"/>
-      </audio>
-      <audio ref="sound_complete">
-        <source src="statics/sounds/time.wav" type="audio/wav"/>
-      </audio>
-      <audio ref="sound_click">
-        <source src="statics/sounds/click.wav" type="audio/wav"/>
-      </audio>
+    <audio ref="sound_begin">
+      <source
+        src="statics/sounds/begin.wav"
+        type="audio/wav"
+      />
+    </audio>
+    <audio ref="sound_minute1">
+      <source
+        src="statics/sounds/1-minute.wav"
+        type="audio/wav"
+      />
+    </audio>
+    <audio ref="sound_minute2">
+      <source
+        src="statics/sounds/2-minutes.wav"
+        type="audio/wav"
+      />
+    </audio>
+    <audio ref="sound_complete">
+      <source
+        src="statics/sounds/time.wav"
+        type="audio/wav"
+      />
+    </audio>
+    <audio ref="sound_click">
+      <source
+        src="statics/sounds/click.wav"
+        type="audio/wav"
+      />
+    </audio>
   </q-page>
 </template>
 
@@ -37,6 +62,10 @@ const TEST_DURATION = 180
 
 export default {
   name: 'QCSTPage',
+  props: {
+    studyKey: String,
+    taskID: String
+  },
   components: {},
   data: function () {
     return {
@@ -97,8 +126,8 @@ export default {
     completeTest () {
       phone.pedometer.stopNotifications()
       this.completionTS = new Date()
-      const studyKey = this.$route.params.studyKey
-      const taskID = parseInt(this.$route.params.taskID)
+      const studyKey = this.studyKey
+      const taskID = parseInt(this.taskID)
       const userKey = userinfo.user._key
       let report = {
         userKey: userKey,

--- a/src/pages/tasks/QCST.vue
+++ b/src/pages/tasks/QCST.vue
@@ -64,7 +64,7 @@ export default {
   name: 'QCSTPage',
   props: {
     studyKey: String,
-    taskID: Number
+    taskId: Number
   },
   components: {},
   data: function () {
@@ -127,12 +127,12 @@ export default {
       phone.pedometer.stopNotifications()
       this.completionTS = new Date()
       const studyKey = this.studyKey
-      const taskID = parseInt(this.taskID)
+      const taskId = parseInt(this.taskId)
       const userKey = userinfo.user._key
       let report = {
         userKey: userKey,
         studyKey: studyKey,
-        taskId: taskID,
+        taskId: taskId,
         createdTS: new Date(),
         startedTS: this.startedTS,
         completionTS: this.completionTS,

--- a/src/pages/tasks/QCST.vue
+++ b/src/pages/tasks/QCST.vue
@@ -64,7 +64,7 @@ export default {
   name: 'QCSTPage',
   props: {
     studyKey: String,
-    taskID: String
+    taskID: Number
   },
   components: {},
   data: function () {

--- a/src/pages/tasks/QCSTHR.vue
+++ b/src/pages/tasks/QCSTHR.vue
@@ -5,7 +5,12 @@
       <p>
         <i>{{ $t("studies.tasks.qcst.enterHRInstructions") }}</i>
       </p>
-      <q-input outlined v-model="heartRate" label="Heart rate" type="number"/>
+      <q-input
+        outlined
+        v-model="heartRate"
+        label="Heart rate"
+        type="number"
+      />
       <q-btn
         color="primary"
         @click="completeTest()"
@@ -19,7 +24,9 @@
 <script>
 export default {
   name: 'QCSTHRPage',
-  props: [ 'report' ],
+  props: {
+    report: Object
+  },
   data: function () {
     return {
       heartRate: undefined

--- a/src/pages/tasks/QCSTIntro.vue
+++ b/src/pages/tasks/QCSTIntro.vue
@@ -46,7 +46,7 @@ export default {
   name: 'QCSTIntroPage',
   props: {
     studyKey: String,
-    taskID: String
+    taskID: Number
   },
   methods: {
     start () {

--- a/src/pages/tasks/QCSTIntro.vue
+++ b/src/pages/tasks/QCSTIntro.vue
@@ -9,7 +9,10 @@
     </div>
     <div>
       <ul>
-        <li v-for="(prerequisite, idx) in $t('studies.tasks.qcst.prerequisites')" :key="idx">
+        <li
+          v-for="(prerequisite, idx) in $t('studies.tasks.qcst.prerequisites')"
+          :key="idx"
+        >
           {{ prerequisite.p }}
         </li>
       </ul>
@@ -19,13 +22,21 @@
     </div>
     <div>
       <ul>
-        <li v-for="(instruction, idx) in $t('studies.tasks.qcst.instructions')" :key="idx">
+        <li
+          v-for="(instruction, idx) in $t('studies.tasks.qcst.instructions')"
+          :key="idx"
+        >
           {{ instruction.i }}
         </li>
       </ul>
     </div>
     <div class="row justify-center q-mt-lg">
-      <q-btn color="primary" @click="start()" replace :label="$t('common.start')" />
+      <q-btn
+        color="primary"
+        @click="start()"
+        replace
+        :label="$t('common.start')"
+      />
     </div>
   </q-page>
 </template>
@@ -33,10 +44,14 @@
 <script>
 export default {
   name: 'QCSTIntroPage',
+  props: {
+    studyKey: String,
+    taskID: String
+  },
   methods: {
     start () {
-      const studyKey = this.$route.params.studyKey
-      const taskID = this.$route.params.taskID
+      const studyKey = this.studyKey
+      const taskID = this.taskID
       console.log('StudyKey ' + studyKey + ',taskID ' + taskID)
       this.$router.push({ name: 'qcst', params: { studyKey, taskID } })
     }

--- a/src/pages/tasks/QCSTIntro.vue
+++ b/src/pages/tasks/QCSTIntro.vue
@@ -45,15 +45,16 @@
 export default {
   name: 'QCSTIntroPage',
   props: {
+    icon: String,
     studyKey: String,
-    taskID: Number
+    taskId: Number
   },
   methods: {
     start () {
       const studyKey = this.studyKey
-      const taskID = this.taskID
-      console.log('StudyKey ' + studyKey + ',taskID ' + taskID)
-      this.$router.push({ name: 'qcst', params: { studyKey, taskID } })
+      const taskId = this.taskId
+      console.log('StudyKey ' + studyKey + ',taskId ' + taskId)
+      this.$router.push({ name: 'qcst', params: { studyKey, taskId } })
     }
   }
 }

--- a/src/pages/tasks/QCSTSummary.vue
+++ b/src/pages/tasks/QCSTSummary.vue
@@ -2,7 +2,11 @@
   <q-page padding>
     <div class="text-center">
       <div class="text-h5">{{ $t('studies.tasks.capTestComplete') }}</div>
-      <img class="q-mt-md" alt="Finish flag" src="~assets/goalflags.svg">
+      <img
+        class="q-mt-md"
+        alt="Finish flag"
+        src="~assets/goalflags.svg"
+      >
       <div class="text-h6 q-mt-md">{{ $t('studies.tasks.capTestCompleteSubtext') }}</div>
       <table id="stats">
         <tr>
@@ -18,97 +22,181 @@
       <div class="q-pa-md">
         <p class="sub-heading">Please rate your level of exertion:</p>
         <q-list bordered>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="0" />
+              <q-radio
+                v-model="borgValue"
+                val="0"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>0 {{ $t('studies.tasks.smwt.borgScale.l0') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="0.5" />
+              <q-radio
+                v-model="borgValue"
+                val="0.5"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>0.5 {{ $t('studies.tasks.smwt.borgScale.l05') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
-            <q-item-section avatar top>
-              <q-radio v-model="borgValue" val="1"/>
+          <q-item
+            tag="label"
+            v-ripple
+          >
+            <q-item-section
+              avatar
+              top
+            >
+              <q-radio
+                v-model="borgValue"
+                val="1"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>1 {{ $t('studies.tasks.smwt.borgScale.l1') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="2"/>
+              <q-radio
+                v-model="borgValue"
+                val="2"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>2 {{ $t('studies.tasks.smwt.borgScale.l2') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="3"/>
+              <q-radio
+                v-model="borgValue"
+                val="3"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>3 {{ $t('studies.tasks.smwt.borgScale.l3') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
-            <q-item-section avatar top>
-              <q-radio v-model="borgValue" val="4"/>
+          <q-item
+            tag="label"
+            v-ripple
+          >
+            <q-item-section
+              avatar
+              top
+            >
+              <q-radio
+                v-model="borgValue"
+                val="4"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>4 {{ $t('studies.tasks.smwt.borgScale.l4') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="5"/>
+              <q-radio
+                v-model="borgValue"
+                val="5"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>5 {{ $t('studies.tasks.smwt.borgScale.l5') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="6" />
+              <q-radio
+                v-model="borgValue"
+                val="6"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>6</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
-            <q-item-section avatar top>
-              <q-radio v-model="borgValue" val="7" />
+          <q-item
+            tag="label"
+            v-ripple
+          >
+            <q-item-section
+              avatar
+              top
+            >
+              <q-radio
+                v-model="borgValue"
+                val="7"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>7 {{ $t('studies.tasks.smwt.borgScale.l7') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="8" />
+              <q-radio
+                v-model="borgValue"
+                val="8"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>8</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="9" />
+              <q-radio
+                v-model="borgValue"
+                val="9"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>9 {{ $t('studies.tasks.smwt.borgScale.l9') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
-            <q-item-section avatar top>
-              <q-radio v-model="borgValue" val="10"/>
+          <q-item
+            tag="label"
+            v-ripple
+          >
+            <q-item-section
+              avatar
+              top
+            >
+              <q-radio
+                v-model="borgValue"
+                val="10"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>10 {{ $t('studies.tasks.smwt.borgScale.l10') }}</q-item>
@@ -121,7 +209,12 @@
         </div>
       </div>
 
-      <q-btn color="primary" @click="send()" :label="$t('common.send')" :disabled="!borgValue"/>
+      <q-btn
+        color="primary"
+        @click="send()"
+        :label="$t('common.send')"
+        :disabled="!borgValue"
+      />
     </div>
   </q-page>
 </template>
@@ -134,7 +227,9 @@ import { format as Qformat } from 'quasar'
 
 export default {
   name: 'QCSTSummaryPage',
-  props: [ 'report' ],
+  props: {
+    report: Object
+  },
   data: function () {
     return {
       borgValue: undefined
@@ -210,7 +305,7 @@ table td:nth-child(2) {
   text-align: right;
 }
 tr {
-  text-align: left
+  text-align: left;
 }
 
 #submit {

--- a/src/pages/tasks/SMWT.vue
+++ b/src/pages/tasks/SMWT.vue
@@ -3,15 +3,36 @@
     <div class="text-center text-h6 q-mt-lg">
       {{ $t('studies.tasks.smwt.title') }}
     </div>
-    <div ref="map" style="width: 100%; height: 50vh;" class="row justify-center items-center">
+    <div
+      ref="map"
+      style="width: 100%; height: 50vh;"
+      class="row justify-center items-center"
+    >
       <span v-if="!mapCannotLoad">{{ $t('studies.tasks.smwt.loadingMap') }}</span>
       <span v-if="mapCannotLoad">{{ $t('studies.tasks.smwt.loadingMapCannot') }}</span>
     </div>
-    <div v-show="isSignalCheck" class="text-subtitle1 text-center ">{{ $t('studies.tasks.smwt.signalCheck') }}</div>
-    <p v-show="!isSignalCheck" id="timer"> {{ minutes }}:{{ seconds }} </p>
+    <div
+      v-show="isSignalCheck"
+      class="text-subtitle1 text-center "
+    >{{ $t('studies.tasks.smwt.signalCheck') }}</div>
+    <p
+      v-show="!isSignalCheck"
+      id="timer"
+    > {{ minutes }}:{{ seconds }} </p>
     <div class="row justify-center q-mt-lg">
-      <q-btn  @click="startTest" v-show="!isStarted" color="secondary" :label="$t('common.start')" :disabled="isSignalCheck" />
-      <q-btn  @click="completeTest" v-show="isStarted" color="purple" :label="$t('common.complete')" />
+      <q-btn
+        @click="startTest"
+        v-show="!isStarted"
+        color="secondary"
+        :label="$t('common.start')"
+        :disabled="isSignalCheck"
+      />
+      <q-btn
+        @click="completeTest"
+        v-show="isStarted"
+        color="purple"
+        :label="$t('common.complete')"
+      />
     </div>
   </q-page>
 </template>
@@ -28,6 +49,10 @@ const SIGNAL_CHECK_TIMEOUT = 60000
 
 export default {
   name: 'SMWTPage',
+  props: {
+    studyKey: String,
+    taskID: String
+  },
   data: function () {
     return {
       map: undefined,
@@ -172,8 +197,8 @@ export default {
       this.distance = distanceAlgo.getDistance()
 
       // package the 6mwt report
-      const studyKey = this.$route.params.studyKey
-      const taskID = parseInt(this.$route.params.taskID)
+      const studyKey = this.studyKey
+      const taskID = parseInt(this.taskID)
       const userKey = userinfo.user._key
       let report = {
         userKey: userKey,

--- a/src/pages/tasks/SMWT.vue
+++ b/src/pages/tasks/SMWT.vue
@@ -51,7 +51,7 @@ export default {
   name: 'SMWTPage',
   props: {
     studyKey: String,
-    taskID: Number
+    taskId: Number
   },
   data: function () {
     return {
@@ -198,12 +198,12 @@ export default {
 
       // package the 6mwt report
       const studyKey = this.studyKey
-      const taskID = parseInt(this.taskID)
+      const taskId = parseInt(this.taskId)
       const userKey = userinfo.user._key
       let report = {
         userKey: userKey,
         studyKey: studyKey,
-        taskId: taskID,
+        taskId: taskId,
         createdTS: new Date(),
         startedTS: this.startedTS,
         completionTS: this.completionTS,

--- a/src/pages/tasks/SMWT.vue
+++ b/src/pages/tasks/SMWT.vue
@@ -51,7 +51,7 @@ export default {
   name: 'SMWTPage',
   props: {
     studyKey: String,
-    taskID: String
+    taskID: Number
   },
   data: function () {
     return {

--- a/src/pages/tasks/SMWTIntro.vue
+++ b/src/pages/tasks/SMWTIntro.vue
@@ -12,13 +12,21 @@
     </div>
     <div>
       <ul>
-        <li v-for="(instruction, idx) in $t('studies.tasks.smwt.instructions')" :key="idx">
+        <li
+          v-for="(instruction, idx) in $t('studies.tasks.smwt.instructions')"
+          :key="idx"
+        >
           {{ instruction.i }}
         </li>
       </ul>
     </div>
     <div class="row justify-center q-mt-lg">
-      <q-btn color="primary" @click="start()" replace :label="$t('common.start')" />
+      <q-btn
+        color="primary"
+        @click="start()"
+        replace
+        :label="$t('common.start')"
+      />
     </div>
   </q-page>
 </template>
@@ -26,10 +34,14 @@
 <script>
 export default {
   name: 'SMWTIntroPage',
+  props: {
+    studyKey: String,
+    taskID: String
+  },
   methods: {
     start () {
-      const studyKey = this.$route.params.studyKey
-      const taskID = this.$route.params.taskID
+      const studyKey = this.studyKey
+      const taskID = this.taskID
       console.log('StudyKey ' + studyKey + ',taskID ' + taskID)
       this.$router.push({ name: 'smwt', params: { studyKey, taskID } })
     }

--- a/src/pages/tasks/SMWTIntro.vue
+++ b/src/pages/tasks/SMWTIntro.vue
@@ -35,15 +35,16 @@
 export default {
   name: 'SMWTIntroPage',
   props: {
+    icon: String,
     studyKey: String,
-    taskID: Number
+    taskId: Number
   },
   methods: {
     start () {
       const studyKey = this.studyKey
-      const taskID = this.taskID
-      console.log('StudyKey ' + studyKey + ',taskID ' + taskID)
-      this.$router.push({ name: 'smwt', params: { studyKey, taskID } })
+      const taskId = this.taskId
+      console.log('StudyKey ' + studyKey + ',taskId ' + taskId)
+      this.$router.push({ name: 'smwt', params: { studyKey, taskId } })
     }
   }
 }

--- a/src/pages/tasks/SMWTIntro.vue
+++ b/src/pages/tasks/SMWTIntro.vue
@@ -36,7 +36,7 @@ export default {
   name: 'SMWTIntroPage',
   props: {
     studyKey: String,
-    taskID: String
+    taskID: Number
   },
   methods: {
     start () {

--- a/src/pages/tasks/SMWTSummary.vue
+++ b/src/pages/tasks/SMWTSummary.vue
@@ -2,7 +2,11 @@
   <q-page padding>
     <div class="text-center">
       <div class="text-h5">{{ $t('studies.tasks.capTestComplete') }}</div>
-      <img class="q-mt-md" alt="Finish flag" src="~assets/goalflags.svg">
+      <img
+        class="q-mt-md"
+        alt="Finish flag"
+        src="~assets/goalflags.svg"
+      >
       <div class="text-h6 q-mt-md">{{ $t('studies.tasks.capTestCompleteSubtext') }}</div>
       <table id="stats">
         <tr>
@@ -22,97 +26,181 @@
       <div class="q-pa-md">
         <p class="sub-heading">Please rate your level of exertion:</p>
         <q-list bordered>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="0" />
+              <q-radio
+                v-model="borgValue"
+                val="0"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>0 {{ $t('studies.tasks.smwt.borgScale.l0') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="0.5" />
+              <q-radio
+                v-model="borgValue"
+                val="0.5"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>0.5 {{ $t('studies.tasks.smwt.borgScale.l05') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
-            <q-item-section avatar top>
-              <q-radio v-model="borgValue" val="1"/>
+          <q-item
+            tag="label"
+            v-ripple
+          >
+            <q-item-section
+              avatar
+              top
+            >
+              <q-radio
+                v-model="borgValue"
+                val="1"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>1 {{ $t('studies.tasks.smwt.borgScale.l1') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="2"/>
+              <q-radio
+                v-model="borgValue"
+                val="2"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>2 {{ $t('studies.tasks.smwt.borgScale.l2') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="3"/>
+              <q-radio
+                v-model="borgValue"
+                val="3"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>3 {{ $t('studies.tasks.smwt.borgScale.l3') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
-            <q-item-section avatar top>
-              <q-radio v-model="borgValue" val="4"/>
+          <q-item
+            tag="label"
+            v-ripple
+          >
+            <q-item-section
+              avatar
+              top
+            >
+              <q-radio
+                v-model="borgValue"
+                val="4"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>4 {{ $t('studies.tasks.smwt.borgScale.l4') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="5"/>
+              <q-radio
+                v-model="borgValue"
+                val="5"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>5 {{ $t('studies.tasks.smwt.borgScale.l5') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="6" />
+              <q-radio
+                v-model="borgValue"
+                val="6"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>6</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
-            <q-item-section avatar top>
-              <q-radio v-model="borgValue" val="7" />
+          <q-item
+            tag="label"
+            v-ripple
+          >
+            <q-item-section
+              avatar
+              top
+            >
+              <q-radio
+                v-model="borgValue"
+                val="7"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>7 {{ $t('studies.tasks.smwt.borgScale.l7') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="8" />
+              <q-radio
+                v-model="borgValue"
+                val="8"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>8</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
+          <q-item
+            tag="label"
+            v-ripple
+          >
             <q-item-section avatar>
-              <q-radio v-model="borgValue" val="9" />
+              <q-radio
+                v-model="borgValue"
+                val="9"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>9 {{ $t('studies.tasks.smwt.borgScale.l9') }}</q-item>
             </q-item-section>
           </q-item>
-          <q-item tag="label" v-ripple>
-            <q-item-section avatar top>
-              <q-radio v-model="borgValue" val="10"/>
+          <q-item
+            tag="label"
+            v-ripple
+          >
+            <q-item-section
+              avatar
+              top
+            >
+              <q-radio
+                v-model="borgValue"
+                val="10"
+              />
             </q-item-section>
             <q-item-section>
               <q-item>10 {{ $t('studies.tasks.smwt.borgScale.l10') }}</q-item>
@@ -125,7 +213,12 @@
         </div>
       </div>
 
-      <q-btn color="primary" @click="send()" :label="$t('common.send')" :disabled="!borgValue"/>
+      <q-btn
+        color="primary"
+        @click="send()"
+        :label="$t('common.send')"
+        :disabled="!borgValue"
+      />
     </div>
 
   </q-page>
@@ -139,7 +232,9 @@ import { format as Qformat } from 'quasar'
 
 export default {
   name: 'SMWTSummaryPage',
-  props: [ 'report' ],
+  props: {
+    report: Object
+  },
   data: function () {
     return {
       borgValue: undefined
@@ -212,7 +307,7 @@ table td:nth-child(2) {
   text-align: right;
 }
 tr {
-  text-align: left
+  text-align: left;
 }
 
 #submit {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -58,12 +58,12 @@ const routes = [
     path: '/tasks',
     component: () => import('layouts/TaskLayout.vue'),
     children: [
-      { path: '/form/:studyKey/:taskId/:formKey', name: 'form', component: () => import('pages/tasks/Form.vue') },
-      { path: '/dataQuery/:studyKey/:taskID', name: 'dataQuery', component: () => import('pages/tasks/DataQuery') },
+      { path: '/form/:studyKey/:taskId/:formKey', name: 'form', component: () => import('pages/tasks/Form.vue'), props: true },
+      { path: '/dataQuery/:studyKey/:taskID', name: 'dataQuery', component: () => import('pages/tasks/DataQuery'), props: true },
       { path: '/smwtIntro/:studyKey/:taskID', name: 'smwtIntro', component: () => import('pages/tasks/SMWTIntro.vue') },
-      { path: '/smwt/:studyKey/:taskID', name: 'smwt', component: () => import('pages/tasks/SMWT.vue') },
+      { path: '/smwt/:studyKey/:taskID', name: 'smwt', component: () => import('pages/tasks/SMWT.vue'), props: true },
       { path: '/smwtSummary', name: 'smwtSummary', component: () => import('pages/tasks/SMWTSummary.vue'), props: true },
-      { path: '/qcstIntro/:studyKey/:taskID', name: 'qcstIntro', component: () => import('pages/tasks/QCSTIntro.vue') },
+      { path: '/qcstIntro/:studyKey/:taskID', name: 'qcstIntro', component: () => import('pages/tasks/QCSTIntro.vue'), props: true },
       { path: '/qcst/:studyKey/:taskID', name: 'qcst', component: () => import('pages/tasks/QCST.vue'), props: true }, // TODO: probably no need for props here
       { path: '/qcsthr', name: 'qcsthr', component: () => import('pages/tasks/QCSTHR.vue'), props: true },
       { path: '/qcstSummary', name: 'qcstSummary', component: () => import('pages/tasks/QCSTSummary.vue'), props: true }

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -60,7 +60,7 @@ const routes = [
     children: [
       { path: '/form', name: 'form', component: () => import('pages/tasks/Form.vue'), props: true },
       { path: '/dataQuery', name: 'dataQuery', component: () => import('pages/tasks/DataQuery'), props: true },
-      { path: '/smwtIntro', name: 'smwtIntro', component: () => import('pages/tasks/SMWTIntro.vue') },
+      { path: '/smwtIntro', name: 'smwtIntro', component: () => import('pages/tasks/SMWTIntro.vue'), props: true },
       { path: '/smwt', name: 'smwt', component: () => import('pages/tasks/SMWT.vue'), props: true },
       { path: '/smwtSummary', name: 'smwtSummary', component: () => import('pages/tasks/SMWTSummary.vue'), props: true },
       { path: '/qcstIntro', name: 'qcstIntro', component: () => import('pages/tasks/QCSTIntro.vue'), props: true },

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -58,16 +58,16 @@ const routes = [
     path: '/tasks',
     component: () => import('layouts/TaskLayout.vue'),
     children: [
-      { path: '/form/:studyKey/:taskId/:formKey', name: 'form', component: () => import('pages/tasks/Form.vue'), props: true },
-      { path: '/dataQuery/:studyKey/:taskID', name: 'dataQuery', component: () => import('pages/tasks/DataQuery'), props: true },
-      { path: '/smwtIntro/:studyKey/:taskID', name: 'smwtIntro', component: () => import('pages/tasks/SMWTIntro.vue') },
-      { path: '/smwt/:studyKey/:taskID', name: 'smwt', component: () => import('pages/tasks/SMWT.vue'), props: true },
+      { path: '/form', name: 'form', component: () => import('pages/tasks/Form.vue'), props: true },
+      { path: '/dataQuery', name: 'dataQuery', component: () => import('pages/tasks/DataQuery'), props: true },
+      { path: '/smwtIntro', name: 'smwtIntro', component: () => import('pages/tasks/SMWTIntro.vue') },
+      { path: '/smwt', name: 'smwt', component: () => import('pages/tasks/SMWT.vue'), props: true },
       { path: '/smwtSummary', name: 'smwtSummary', component: () => import('pages/tasks/SMWTSummary.vue'), props: true },
-      { path: '/qcstIntro/:studyKey/:taskID', name: 'qcstIntro', component: () => import('pages/tasks/QCSTIntro.vue'), props: true },
-      { path: '/qcst/:studyKey/:taskID', name: 'qcst', component: () => import('pages/tasks/QCST.vue'), props: true }, // TODO: probably no need for props here
+      { path: '/qcstIntro', name: 'qcstIntro', component: () => import('pages/tasks/QCSTIntro.vue'), props: true },
+      { path: '/qcst', name: 'qcst', component: () => import('pages/tasks/QCST.vue'), props: true },
       { path: '/qcsthr', name: 'qcsthr', component: () => import('pages/tasks/QCSTHR.vue'), props: true },
       { path: '/qcstSummary', name: 'qcstSummary', component: () => import('pages/tasks/QCSTSummary.vue'), props: true }
-      // { path: '/miband3Intro/:studyKey/:taskID', name: 'miband3Intro', component: () => import('pages/tasks/MiBand3Intro') }
+      // { path: '/miband3Intro', name: 'miband3Intro', component: () => import('pages/tasks/MiBand3Intro'), props: true }
     ]
   }
 ]


### PR DESCRIPTION
Task parameters are now sent as params to named routes in TaskListItem.vue, through each /tasks child in routes.js, and finally received in each child in a props object.

props have been removed from the paths in routes.js (:studyKey, :taskID), which fixes #74 