### PR TITLE
Task layout updated to include task title and icon in header

### DIFF
--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -32,22 +32,24 @@ export default {
   },
   methods: {
     changeRoute: function () {
+      const title = this.title
       const icon = this.icon
+      const type = this.task.type
       const studyKey = this.task.studyKey
       const taskId = this.task.taskId
       const formKey = this.task.formKey
 
-      console.log(this.title, '\nIcon:', icon, '\nStudy Key:', studyKey, '\nTask ID:', taskId)
+      console.log(title, '\nIcon:', icon, '\nStudy Key:', studyKey, '\nTask ID:', taskId)
 
       // these bring the user to the correct route depending on the task
-      if (this.task.formKey) {
-        this.$router.push({ name: 'form', params: { icon: icon, studyKey: studyKey, taskId: taskId, formKey: formKey } })
-      } else if (this.task.type === 'smwt') {
-        this.$router.push({ name: 'smwtIntro', params: { icon: icon, studyKey: studyKey, taskId: taskId } })
-      } else if (this.task.type === 'qcst') {
-        this.$router.push({ name: 'qcstIntro', params: { icon: icon, studyKey: studyKey, taskId: taskId } })
-      } else if (this.task.studyKey && this.task.taskId) {
-        this.$router.push({ name: 'dataQuery', params: { icon: icon, taskId: taskId, studyKey: studyKey } })
+      if (formKey) {
+        this.$router.push({ name: 'form', params: { title: title, icon: icon, studyKey: studyKey, taskId: taskId, formKey: formKey } })
+      } else if (type === 'smwt') {
+        this.$router.push({ name: 'smwtIntro', params: { title: title, icon: icon, studyKey: studyKey, taskId: taskId } })
+      } else if (type === 'qcst') {
+        this.$router.push({ name: 'qcstIntro', params: { title: title, icon: icon, studyKey: studyKey, taskId: taskId } })
+      } else if (studyKey && taskId) {
+        this.$router.push({ name: 'dataQuery', params: { title: title, icon: icon, taskId: taskId, studyKey: studyKey } })
       } else {
         return false
       }

--- a/src/components/TaskListItem.vue
+++ b/src/components/TaskListItem.vue
@@ -32,10 +32,10 @@ export default {
   },
   methods: {
     changeRoute: function () {
-      let icon = this.icon
-      let studyKey = this.task.studyKey
-      let taskId = this.task.taskId
-      let formKey = this.task.formKey
+      const icon = this.icon
+      const studyKey = this.task.studyKey
+      const taskId = this.task.taskId
+      const formKey = this.task.formKey
 
       console.log(this.title, '\nIcon:', icon, '\nStudy Key:', studyKey, '\nTask ID:', taskId)
 

--- a/src/layouts/TaskLayout.vue
+++ b/src/layouts/TaskLayout.vue
@@ -5,13 +5,19 @@
       elevated
       class="bg-primary text-white"
     >
-      <q-toolbar id="tasker">
+      <q-toolbar>
+        <q-avatar>
+          <q-icon
+            color="white"
+            :name="this.$route.params.icon"
+          />
+        </q-avatar>
+        <q-toolbar-title>{{ this.$route.params.title }}</q-toolbar-title>
         <q-btn
           flat
           dense
           @click="confirm = true"
           icon-right="clear"
-          :label="$t('layouts.close')"
         />
       </q-toolbar>
     </q-header>
@@ -52,7 +58,7 @@
         leave-active-class="fadeOut"
         mode="out-in"
       >
-        <router-view @updateTransition="update"/>
+        <router-view @updateTransition="update" />
       </transition>
     </q-page-container>
   </q-layout>
@@ -81,14 +87,9 @@ export default {
 </script>
 
 <style>
-#tasker {
-  justify-content: flex-end;
-}
-.q-toolbar__title {
-  flex: none;
-}
-.q-avatar {
-  margin: 0px 0px 5px 5px;
+.text-h6,
+.text-h5 {
+  margin-top: 20px;
 }
 .block {
   margin-top: 2px;

--- a/src/pages/tasks/DataQuery.vue
+++ b/src/pages/tasks/DataQuery.vue
@@ -54,6 +54,7 @@ const chartColors = [
 export default {
   name: 'DataQueryPage',
   props: {
+    title: String,
     icon: String,
     studyKey: String,
     taskId: Number

--- a/src/pages/tasks/Form.vue
+++ b/src/pages/tasks/Form.vue
@@ -22,57 +22,60 @@
         leave-active-class="fadeOut"
         mode="out-in"
       >
-      <div v-show="slideName != ''" key="">
-        <div class="text-center text-subtitle1">
-          <div v-html="currentQuestion.text[$i18n.locale]"></div>
-        </div>
         <div
-          v-if="currentQuestion.helper"
-          class="text-center text-subtitle2 q-mb-md"
+          v-show="slideName != ''"
+          key=""
         >
-          <div v-html="currentQuestion.helper[$i18n.locale]"></div>
-        </div>
+          <div class="text-center text-subtitle1">
+            <div v-html="currentQuestion.text[$i18n.locale]"></div>
+          </div>
+          <div
+            v-if="currentQuestion.helper"
+            class="text-center text-subtitle2 q-mb-md"
+          >
+            <div v-html="currentQuestion.helper[$i18n.locale]"></div>
+          </div>
 
-        <q-input
-          v-show="currentQuestion.type === 'freetext'"
-          v-model="freetextAnswer"
-          type="textarea"
-          :label="$t('studies.tasks.form.freeTextExplanation')"
-          rows="3"
-          outlined
-        />
+          <q-input
+            v-show="currentQuestion.type === 'freetext'"
+            v-model="freetextAnswer"
+            type="textarea"
+            :label="$t('studies.tasks.form.freeTextExplanation')"
+            rows="3"
+            outlined
+          />
 
-        <div
-          v-show="currentQuestion.type === 'singleChoice'"
-          v-for="(answerChoice, index) in currentQuestion.answerChoices"
-          :key="'sc' + index"
-        >
-          <q-radio
-            v-model="singleChoiceAnswer"
-            :val="answerChoice.id"
-            :label="answerChoice.text[$i18n.locale]"
-          />
-        </div>
-        <div
-          v-show="currentQuestion.type === 'multiChoice'"
-          v-for="(answerChoice, index) in currentQuestion.answerChoices"
-          :key="'mc' + index"
-        >
-          <q-checkbox
-            v-model="multiChoiceAnswer"
-            :val="answerChoice.id"
-            :label="answerChoice.text[$i18n.locale]"
-          />
-        </div>
-        <div
-          v-show="currentQuestion.type === 'textOnly'"
-          class="text-subtitle1 q-mb-md"
-        >
-          <div v-if="currentQuestion.type === 'textOnly'">
-            <div v-html="currentQuestion.html[$i18n.locale]"></div>
+          <div
+            v-show="currentQuestion.type === 'singleChoice'"
+            v-for="(answerChoice, index) in currentQuestion.answerChoices"
+            :key="'sc' + index"
+          >
+            <q-radio
+              v-model="singleChoiceAnswer"
+              :val="answerChoice.id"
+              :label="answerChoice.text[$i18n.locale]"
+            />
+          </div>
+          <div
+            v-show="currentQuestion.type === 'multiChoice'"
+            v-for="(answerChoice, index) in currentQuestion.answerChoices"
+            :key="'mc' + index"
+          >
+            <q-checkbox
+              v-model="multiChoiceAnswer"
+              :val="answerChoice.id"
+              :label="answerChoice.text[$i18n.locale]"
+            />
+          </div>
+          <div
+            v-show="currentQuestion.type === 'textOnly'"
+            class="text-subtitle1 q-mb-md"
+          >
+            <div v-if="currentQuestion.type === 'textOnly'">
+              <div v-html="currentQuestion.html[$i18n.locale]"></div>
+            </div>
           </div>
         </div>
-      </div>
       </transition>
       <div class="row justify-around q-ma-lg">
         <q-btn
@@ -122,6 +125,7 @@ import userinfo from 'modules/userinfo'
 export default {
   name: 'FormPage',
   props: {
+    title: String,
     icon: String,
     studyKey: String,
     taskId: Number,
@@ -309,7 +313,9 @@ export default {
 </script>
 
 <style scoped>
-.slideInLeft, .slideInRight, .fadeInDown {
+.slideInLeft,
+.slideInRight,
+.fadeInDown {
   animation-duration: 600ms;
 }
 </style>

--- a/src/pages/tasks/QCST.vue
+++ b/src/pages/tasks/QCST.vue
@@ -129,6 +129,8 @@ export default {
     completeTest () {
       phone.pedometer.stopNotifications()
       this.completionTS = new Date()
+      const title = this.title
+      const icon = this.icon
       const studyKey = this.studyKey
       const taskId = parseInt(this.taskId)
       const userKey = userinfo.user._key
@@ -143,7 +145,7 @@ export default {
         heartRate: undefined,
         borgScale: undefined
       }
-      this.$router.push({ name: 'qcsthr', params: { report: report } })
+      this.$router.push({ name: 'qcsthr', params: { title: title, icon: icon, report: report } })
     }
   },
   computed: {

--- a/src/pages/tasks/QCST.vue
+++ b/src/pages/tasks/QCST.vue
@@ -63,6 +63,8 @@ const TEST_DURATION = 180
 export default {
   name: 'QCSTPage',
   props: {
+    title: String,
+    icon: String,
     studyKey: String,
     taskId: Number
   },

--- a/src/pages/tasks/QCSTHR.vue
+++ b/src/pages/tasks/QCSTHR.vue
@@ -25,6 +25,8 @@
 export default {
   name: 'QCSTHRPage',
   props: {
+    title: String,
+    icon: String,
     report: Object
   },
   data: function () {

--- a/src/pages/tasks/QCSTHR.vue
+++ b/src/pages/tasks/QCSTHR.vue
@@ -36,8 +36,11 @@ export default {
   },
   methods: {
     completeTest () {
+      const title = this.title
+      const icon = this.icon
+      const report = this.report
       this.report.heartRate = this.heartRate
-      this.$router.push({ name: 'qcstSummary', params: { report: this.report } })
+      this.$router.push({ name: 'qcstSummary', params: { title: title, icon: icon, report: report } })
     }
   }
 }

--- a/src/pages/tasks/QCSTIntro.vue
+++ b/src/pages/tasks/QCSTIntro.vue
@@ -45,6 +45,7 @@
 export default {
   name: 'QCSTIntroPage',
   props: {
+    title: String,
     icon: String,
     studyKey: String,
     taskId: Number

--- a/src/pages/tasks/QCSTIntro.vue
+++ b/src/pages/tasks/QCSTIntro.vue
@@ -52,10 +52,12 @@ export default {
   },
   methods: {
     start () {
+      const title = this.title
+      const icon = this.icon
       const studyKey = this.studyKey
       const taskId = this.taskId
       console.log('StudyKey ' + studyKey + ',taskId ' + taskId)
-      this.$router.push({ name: 'qcst', params: { studyKey, taskId } })
+      this.$router.push({ name: 'qcst', params: { title, icon, studyKey, taskId } })
       this.$emit('updateTransition', 'fadeInDown')
     }
   }

--- a/src/pages/tasks/QCSTSummary.vue
+++ b/src/pages/tasks/QCSTSummary.vue
@@ -228,6 +228,8 @@ import { format as Qformat } from 'quasar'
 export default {
   name: 'QCSTSummaryPage',
   props: {
+    title: String,
+    icon: String,
     report: Object
   },
   data: function () {

--- a/src/pages/tasks/SMWT.vue
+++ b/src/pages/tasks/SMWT.vue
@@ -172,6 +172,8 @@ export default {
       this.distance = distanceAlgo.getDistance()
 
       // package the 6mwt report
+      const title = this.title
+      const icon = this.icon
       const studyKey = this.studyKey
       const taskId = parseInt(this.taskId)
       const userKey = userinfo.user._key
@@ -188,7 +190,7 @@ export default {
         borgScale: undefined
       }
 
-      this.$router.push({ name: 'smwtSummary', params: { report: report } })
+      this.$router.push({ name: 'smwtSummary', params: { title: title, icon: icon, report: report } })
       this.$emit('updateTransition', 'slideInRight')
     }
   },

--- a/src/pages/tasks/SMWT.vue
+++ b/src/pages/tasks/SMWT.vue
@@ -49,6 +49,8 @@ const SIGNAL_CHECK_TIMEOUT = 60000
 export default {
   name: 'SMWTPage',
   props: {
+    title: String,
+    icon: String,
     studyKey: String,
     taskId: Number
   },

--- a/src/pages/tasks/SMWTIntro.vue
+++ b/src/pages/tasks/SMWTIntro.vue
@@ -35,6 +35,7 @@
 export default {
   name: 'SMWTIntroPage',
   props: {
+    title: String,
     icon: String,
     studyKey: String,
     taskId: Number

--- a/src/pages/tasks/SMWTIntro.vue
+++ b/src/pages/tasks/SMWTIntro.vue
@@ -42,10 +42,12 @@ export default {
   },
   methods: {
     start () {
+      const title = this.title
+      const icon = this.icon
       const studyKey = this.studyKey
       const taskId = this.taskId
       console.log('StudyKey ' + studyKey + ',taskId ' + taskId)
-      this.$router.push({ name: 'smwt', params: { studyKey, taskId } })
+      this.$router.push({ name: 'smwt', params: { title: title, icon: icon, studyKey, taskId } })
       this.$emit('updateTransition', 'fadeInDown')
     }
   }

--- a/src/pages/tasks/SMWTSummary.vue
+++ b/src/pages/tasks/SMWTSummary.vue
@@ -233,6 +233,8 @@ import { format as Qformat } from 'quasar'
 export default {
   name: 'SMWTSummaryPage',
   props: {
+    title: String,
+    icon: String,
     report: Object
   },
   data: function () {


### PR DESCRIPTION
Added both title and icon to the params routed from TaskListItem.vue and to the props in each. Also made sure to pass title and icon as params in router push statements between task pages (e.g. from 6MWTIntro to 6MWT).

Fixes #77