### PR TITLE
Position task fix error notification

### DIFF
--- a/src/modules/API/mockdata/formAAMOSweekly.json
+++ b/src/modules/API/mockdata/formAAMOSweekly.json
@@ -408,6 +408,17 @@
           }
         }
       ]
+    },
+    {
+      "id": "Q11",
+      "text": {
+        "en": "Please describe any other asthma symptoms you have experienced over the last week."
+      },
+      "helper": {
+        "en": ""
+      },
+      "footer": {},
+      "type": "freetext"
     }
   ],
   "created": "2021-03-31T15:15:04.786Z"

--- a/src/pages/tasks/position/Position.vue
+++ b/src/pages/tasks/position/Position.vue
@@ -70,9 +70,10 @@ export default {
         color: 'negative',
         message: 'No positioning available',
         icon: 'report_problem',
-        onDismiss () {
-          this.$router.push('/home')
-        }
+        timeout: 0, // will not disapper until dismissed
+        actions: [
+          { label: 'Dismiss', color: 'white', handler: () => { this.$router.push('/home') } }
+        ]
       })
     } else {
       this.showConnecting = true
@@ -86,9 +87,10 @@ export default {
           color: 'negative',
           message: this.$t('errors.connectionError') + ' ' + err.message,
           icon: 'report_problem',
-          onDismiss () {
-            this.$router.push('/home')
-          }
+          timeout: 0, // will not disapper until dismissed
+          actions: [
+            { label: 'Dismiss', color: 'white', handler: () => { this.$router.push('/home') } }
+          ]
         })
       }
       this.showConnecting = false


### PR DESCRIPTION
the previous q.notify onDismiss function doesn't recognise this.$router when first mounted. New function: error message will remain on screen until dismissed, then return to /home